### PR TITLE
Fix wrapped text being incorrectly indented.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,4 @@
 [
-  {"keys": ["ctrl+f11"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "source.Wiki"} ] },
-  {"keys": ["ctrl+enter"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "source.Wiki"} ] }
+  {"keys": ["ctrl+f11"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "text.Wiki"} ] },
+  {"keys": ["ctrl+enter"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "text.Wiki"} ] }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
-  {"keys": ["ctrl+f11"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "source.Wiki"} ] },
-  {"keys": ["ctrl+enter"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "source.Wiki"} ] }
+  {"keys": ["ctrl+f11"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "text.Wiki"} ] },
+  {"keys": ["ctrl+enter"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "text.Wiki"} ] }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,4 @@
 [
-  {"keys": ["ctrl+f11"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "source.Wiki"} ] },
-  {"keys": ["ctrl+enter"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "source.Wiki"} ] }
+  {"keys": ["ctrl+f11"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "text.Wiki"} ] },
+  {"keys": ["ctrl+enter"], "command": "wiki_link", "context": [{"key": "selector", "operator": "equal", "operand": "text.Wiki"} ] }
 ]

--- a/Wiki.tmLanguage
+++ b/Wiki.tmLanguage
@@ -72,7 +72,7 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.Wiki</string>
+	<string>text.Wiki</string>
 	<key>uuid</key>
 	<string>14883dd8-b120-4a1e-a4c5-67c5e7815344</string>
 </dict>


### PR DESCRIPTION
Before this fix:

```
Lorem ipsum dolor sit amet, consectetur adipisici
    elit, sed do eiusmod tempor incididunt labore 
    et dolore magna aliqua. Ut enim ad minim veni, 
    quis nostrud exercitation ullamco laboris
```

After this fix:

```
Lorem ipsum dolor sit amet, consectetur adipisici
elit, sed do eiusmod tempor incididunt labore et 
dolore magna aliqua. Ut enim ad minim veni, quis 
nostrud exercitation ullamco laboris
```

More info here: https://github.com/jashkenas/coffee-script-tmbundle/pull/132

"It seems Sublime Text 2 have a habit of pushing subsequent lines of 
wrapped code one indentation level to the right. It does not do this 
with text (as opposed to code). Whether scope is considered code or text
depends on scopeName property. If it starts with `source`. - then it's 
code. If it starts with `text`. - then it's text."